### PR TITLE
Attempt to force MySQL to use index on TranslationGroupID instead of SiteTree.Sort

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,14 @@ php:
   - 5.6
 
 env:
-  - DB=MYSQL CORE_RELEASE=3
+  - DB=MYSQL CORE_RELEASE=3.7
 
 matrix:
   include:
     - php: 5.6
-      env: DB=PGSQL CORE_RELEASE=3
+      env: DB=PGSQL CORE_RELEASE=3.7
     - php: 5.6
-      env: DB=MYSQL CORE_RELEASE=3
+      env: DB=MYSQL CORE_RELEASE=3.7
 
 before_script:
  - pear -q install --onlyreqdeps pear/PHP_CodeSniffer

--- a/code/model/Translatable.php
+++ b/code/model/Translatable.php
@@ -1296,16 +1296,14 @@ class Translatable extends DataExtension implements PermissionProvider {
 		}
 		$joinOnClause = sprintf('"%s_translationgroups"."OriginalID" = "%s"."ID"', $baseDataClass, $baseDataClass);
 		if($this->owner->hasExtension("Versioned") && $stage) {
-			$translations = Versioned::get_by_stage(
-				$baseDataClass,
-				$stage,
-				$filter, 
-				null
-			)->leftJoin("{$baseDataClass}_translationgroups", $joinOnClause);
+			$translations = Versioned::get_by_stage($baseDataClass, $stage, $filter, null)
+				->leftJoin("{$baseDataClass}_translationgroups", $joinOnClause)
+				->sort(sprintf('"%s_translationgroups"."TranslationGroupID"', $baseDataClass));
 		} else {
 			$translations = DataObject::get($baseDataClass)
 				->where($filter)
-				->leftJoin("{$baseDataClass}_translationgroups", $joinOnClause);
+				->leftJoin("{$baseDataClass}_translationgroups", $joinOnClause)
+				->sort(sprintf('"%s_translationgroups"."TranslationGroupID"', $baseDataClass));
 		}
 
 		// only re-enable locale-filter if it was enabled at the beginning of this method


### PR DESCRIPTION
For the translation lookup query in `getTranslations`, we noticed that MySQL would sometimes use a query plan that would `ORDER BY` the `SiteTree.Sort` field and then limit by `TranslationGroupID`. This query plan made this query, that should run in <10ms, take >100sec depending on the size of SiteTree. This commit adds a hack to force MySQL to use the `TranslationGroupID` index rather than the `SiteTree.Sort` index.