### PR TITLE
fix: keep parent fields when a default locale node doesn't exist

### DIFF
--- a/code/model/Translatable.php
+++ b/code/model/Translatable.php
@@ -1185,10 +1185,12 @@ class Translatable extends DataExtension implements PermissionProvider {
 		$isTranslationMode = $this->owner->Locale != Translatable::default_locale();
 		
 		if($originalRecord && $isTranslationMode) {
-			// Remove parent page dropdown
-			$fields->removeByName("ParentType");
-			$fields->removeByName("ParentID");
-			
+			if ($originalRecord->Locale === Translatable::default_locale()) {
+				// Remove parent page dropdown
+				$fields->removeByName("ParentType");
+				$fields->removeByName("ParentID");
+			}
+
 			$translatableFieldNames = $this->getTranslatableFields();
 			$allDataFields = $fields->dataFields();
 			


### PR DESCRIPTION
This is a slight modification to the logic originally added in https://github.com/silverstripe/silverstripe-framework/commit/aafaee660bed2